### PR TITLE
[WIP] Add end to end tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-    "extends": "airbnb-base",
-    "plugins": [
-        "import"
-    ]
-};

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .DS_Store
+coverage
+.nyc_output

--- a/index.js
+++ b/index.js
@@ -46,10 +46,10 @@ packagesName.map((p) => {
 	spinner.fail(chalk.red.bold(`${p} - ${getText('error')}`));
 	console.log(chalk`
 It was created by:
-  {blue.bold ${showAuthor(data)} }
+  {blue.bold ${showAuthor(data)}}
 
 It's at version:
-  {blue.bold ${data['dist-tags'].latest} }
+  {blue.bold ${data['dist-tags'].latest}}
 
 You can find it at:
   https://www.npmjs.com/package/${p}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^4.2.0",
     "eslint-config-airbnb-base": "^11.2.0",
     "eslint-plugin-import": "^2.7.0",
+    "execa": "^0.7.0",
     "xo": "^0.18.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && nyc ava --verbose"
   },
   "files": [
     "index.js",
@@ -36,8 +36,8 @@
   "devDependencies": {
     "ava": "^0.20.0",
     "babel-cli": "^6.24.1",
-    "babel-env": "^2.4.1",
-    "xo": "^0.18.2",
-    "execa": "^0.7.0"
+    "execa": "^0.7.0",
+    "nyc": "^11.0.3",
+    "xo": "^0.18.2"
   }
 }

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -1,18 +1,18 @@
 const test = require('ava');
 const execa = require('execa');
 
-test('package name not given', t => {
+test('package name not given', async t => {
 	const expected = '\nYou need to pass a package name so I can do my thing 😉';
 
-	return execa('node', ['index']).then(result => {
+	await execa('node', ['index']).then(result => {
 		t.is(result.stdout, expected);
 	});
 });
 
-test('package is available', t => {
+test('package is available', async t => {
 	const expected = '✔ no-way-this-is-taken - NICE! The name is not taken you can claim it! 🍕 🎉🎉🎉';
 
-	return execa('node', ['index', 'no-way-this-is-taken']).then(result => {
+	await execa('node', ['index', 'no-way-this-is-taken']).then(result => {
     /*
       Found a bug here
 
@@ -30,7 +30,7 @@ test('package is available', t => {
 
   Example: https://npmjs.com/@siddharthkp/empty
 */
-test('package already exists', t => {
+test('package already exists', async t => {
 	const expectedStderr = '✖ react - Damn it, the name is already taken ☹️';
 	const expectedStdout = `
 It was created by:
@@ -45,13 +45,13 @@ You can find it at:
 
 	`;
 
-	return execa('node', ['index', 'react']).then(result => {
+	await execa('node', ['index', 'react']).then(result => {
 		t.is(result.stderr, expectedStderr);
 		t.is(result.stdout, expectedStdout);
 	});
 });
 
-test('gives help text', t => {
+test('gives help text', async t => {
 	const expected = `
   A cli tool to help you see a npm name is already taken because this a problem now 😱
 
@@ -63,7 +63,7 @@ test('gives help text', t => {
      > No this name is already taken
 	`;
 
-	return execa('node', ['index', '--help']).then(result => {
+	await execa('node', ['index', '--help']).then(result => {
 		t.is(result.stdout, expected);
 	});
 });

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -1,0 +1,72 @@
+const test = require('ava');
+const execa = require('execa');
+
+test('package name not given', t => {
+  const expected = '\nYou need to pass a package name so I can do my thing 😉';
+
+  return execa('node', ['index']).then(result => {
+  	t.is(result.stdout, expected)
+  });
+});
+
+
+test('package is available', t => {
+  const expected = '✔ no-way-this-is-taken - NICE! The name is not taken you can claim it! 🍕 🎉🎉🎉';
+
+  return execa('node', ['index', 'no-way-this-is-taken']).then(result => {
+    /*
+      Found a bug here
+
+      The message is given in stderr, not stdout
+    */
+  	t.is(result.stderr, expected)
+  });
+});
+
+/*
+  This is very fragile test, as it depends on an external project.
+
+  An alternative way of doing this is to create a dummy package
+  that you can rely on.
+
+  Example: https://npmjs.com/@siddharthkp/empty
+*/
+test('package already exists', t => {
+
+  const expectedStderr = '✖ react - Damn it, the name is already taken ☹️';
+  const expectedStdout = `
+It was created by:
+  fb - opensource+npm@fb.com
+  spicyj - ben@benalpert.com
+
+It's at version:
+  15.6.1
+
+You can find it at:
+  https://www.npmjs.com/package/react
+
+	`;
+
+  return execa('node', ['index', 'react']).then(result => {
+    t.is(result.stderr, expectedStderr)
+  	t.is(result.stdout, expectedStdout)
+  });
+});
+
+test('gives help text', t => {
+
+  const expected = `
+  A cli tool to help you see a npm name is already taken because this a problem now 😱
+
+  Usage
+    $ canisuseit [input]
+
+  Examples
+    $ canisuseit lodash
+     > No this name is already taken
+	`;
+
+  return execa('node', ['index', '--help']).then(result => {
+    t.is(result.stdout, expected)
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,0 @@
-const test = require('ava')
-
-test.todo('Write some tests')

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,3 @@
+const test = require('ava')
+
+test.todo('Write some tests')


### PR DESCRIPTION
Warning: Long post ahead.

By writing end to end tests for this, I have learned that these tests are a horrible idea for CLIs and unit tests will fair better 😋 

Read on...

This is how end to end tests would look:

```js
const expectedOutput = '✅ no-way-this-is-taken - NICE! The name is not taken you can claim it! 🍕 🎉🎉🎉';

run('node index no-way-this-is-taken').then(output => {
  t.is(output, expectedOutput); // are they same?
});
```

There are 2 problems with this approach:

1. Tests for existing packages are very fragile. They depend on the external package. The versions and authors would change and break your tests 🙈 

      You can get away with it by using a dummy package like [@siddharthkp/empty](https://npmjs.com/@siddharthkp/empty). But, that makes me feel icky 😅

2. With this approach, everytime your messaging changes, the tests will break. That's a lot of overhead to maintain.

      Don't get me wrong, it will also catch some bugs when they come, but that would not be the most common case. So, it's more noise than signal. Boo!

---

A better way of doing this would be to break the package into 2 parts.

- cli.js: this is the entry point
- src/api.js: this is where all the logic is
- src/text.js

This way you can include the `api` and write unit tests on top of it, without printing anything to stdout.

However, this way you would not be able to test all the functionality of the tool - example: did the spinner turn into a ✅ or not?
But, you will be able to test the core of it. That's where features/bugs are expected to be added more.

---

Summary: 

Break `index.js` into parts, test the functions 😄 